### PR TITLE
Add Rust bindings for Redis Module Command Filter APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,10 @@ crate-type = ["cdylib"]
 name = "expire"
 crate-type = ["cdylib"]
 
+[[example]]
+name = "command_filter"
+crate-type = ["cdylib"]
+
 [dependencies]
 bitflags = "2"
 libc = "0.2"

--- a/examples/command_filter.rs
+++ b/examples/command_filter.rs
@@ -1,10 +1,10 @@
 use redis_module::{
-    raw, redis_module, Context, NextArg, RedisError, RedisResult, RedisString, RedisValue,
-    CommandFilter, CommandFilterContext,
+    raw, redis_module, CommandFilter, CommandFilterContext, Context, NextArg, RedisError,
+    RedisResult, RedisString, RedisValue,
 };
 use std::sync::atomic::{AtomicPtr, Ordering};
 
-static COMMAND_FILTER: AtomicPtr<raw::RedisModuleCommandFilter> = 
+static COMMAND_FILTER: AtomicPtr<raw::RedisModuleCommandFilter> =
     AtomicPtr::new(std::ptr::null_mut());
 
 extern "C" fn command_filter_callback(fctx: *mut raw::RedisModuleCommandFilterCtx) {
@@ -19,14 +19,14 @@ fn command_filter_impl(fctx: &CommandFilterContext) {
         if cmd_str.eq_ignore_ascii_case("set") {
             // You can inspect or modify arguments here
             // For example, you could replace sensitive data
-            
+
             // Get all arguments (excluding command)
             let args = fctx.get_all_args_wo_cmd();
             let _num_args = args.len();
-            
+
             // Note: In a real implementation, you would use the Context
             // to log, but we don't have access to it in the filter callback
-            
+
             #[cfg(any(
                 feature = "min-redis-compatibility-version-7-4",
                 feature = "min-redis-compatibility-version-7-2"
@@ -40,20 +40,20 @@ fn command_filter_impl(fctx: &CommandFilterContext) {
 
 fn filter_register(ctx: &Context, _args: Vec<RedisString>) -> RedisResult {
     let current = COMMAND_FILTER.load(Ordering::Acquire);
-    
+
     if !current.is_null() {
         return Err(RedisError::String("Filter already registered".to_string()));
     }
-    
+
     let filter = ctx.register_command_filter(command_filter_callback, 0);
     COMMAND_FILTER.store(filter.as_ptr(), Ordering::Release);
-    
+
     Ok(RedisValue::SimpleStringStatic("OK"))
 }
 
 fn filter_unregister(ctx: &Context, _args: Vec<RedisString>) -> RedisResult {
     let filter_ptr = COMMAND_FILTER.swap(std::ptr::null_mut(), Ordering::AcqRel);
-    
+
     if !filter_ptr.is_null() {
         let filter = CommandFilter::new(filter_ptr);
         ctx.unregister_command_filter(&filter);
@@ -67,20 +67,20 @@ fn filter_test_args(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     let mut args_iter = args.into_iter().skip(1);
     let key = args_iter.next_arg()?;
     let value = args_iter.next_arg()?;
-    
+
     // This SET command will be intercepted by the filter if it's registered
     ctx.call("SET", &[&key, &value])?;
-    
+
     Ok(RedisValue::SimpleStringStatic("OK"))
 }
 
 fn filter_modify_example(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     // This example demonstrates how to modify command arguments in a filter
     // In this case, we'll register a temporary filter that adds a prefix to SET keys
-    
+
     extern "C" fn modify_filter(fctx: *mut raw::RedisModuleCommandFilterCtx) {
         let filter_ctx = CommandFilterContext::new(fctx);
-        
+
         // Check if this is a SET command
         if let Ok(cmd) = filter_ctx.cmd_get_try_as_str() {
             if cmd.eq_ignore_ascii_case("set") && filter_ctx.args_count() >= 2 {
@@ -93,17 +93,17 @@ fn filter_modify_example(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
             }
         }
     }
-    
+
     let filter = ctx.register_command_filter(modify_filter, 0);
-    
+
     // Execute a SET command which will be modified by the filter
     if args.len() > 2 {
         let _ = ctx.call("SET", &[&args[1], &args[2]]);
     }
-    
+
     // Unregister the filter
     ctx.unregister_command_filter(&filter);
-    
+
     Ok(RedisValue::SimpleStringStatic("OK"))
 }
 

--- a/examples/command_filter.rs
+++ b/examples/command_filter.rs
@@ -1,0 +1,154 @@
+use redis_module::{
+    redis_module, Context, NextArg, RedisError, RedisResult, RedisString, RedisValue,
+};
+use redis_module::CommandFilterContext;
+
+static mut COMMAND_FILTER: Option<*mut redis_module::raw::RedisModuleCommandFilter> = None;
+
+fn command_filter_callback(fctx: &CommandFilterContext) {
+    // Get the number of arguments
+    let argc = fctx.args_count();
+    
+    if argc > 0 {
+        // Get the command name (first argument)
+        if let Some(cmd) = fctx.arg_get(0) {
+            if let Ok(cmd_str) = cmd.try_as_str() {
+                // Example: Log all SET commands
+                if cmd_str.eq_ignore_ascii_case("set") {
+                    // You can inspect or modify arguments here
+                    // For example, you could replace sensitive data
+                    
+                    // Note: In a real implementation, you would use the Context
+                    // to log, but we don't have access to it in the filter callback
+                }
+            }
+        }
+    }
+}
+
+fn filter_register(ctx: &Context, _args: Vec<RedisString>) -> RedisResult {
+    unsafe {
+        if COMMAND_FILTER.is_some() {
+            return Err(RedisError::String("Filter already registered".to_string()));
+        }
+        
+        let filter = ctx.register_command_filter(command_filter_callback, 0);
+        COMMAND_FILTER = Some(filter);
+    }
+    
+    Ok(RedisValue::SimpleStringStatic("OK"))
+}
+
+fn filter_unregister(ctx: &Context, _args: Vec<RedisString>) -> RedisResult {
+    unsafe {
+        if let Some(filter) = COMMAND_FILTER {
+            ctx.unregister_command_filter(filter)?;
+            COMMAND_FILTER = None;
+            Ok(RedisValue::SimpleStringStatic("OK"))
+        } else {
+            Err(RedisError::String("No filter registered".to_string()))
+        }
+    }
+}
+
+fn filter_test_args(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
+    let mut args_iter = args.into_iter().skip(1);
+    let key = args_iter.next_arg()?;
+    let value = args_iter.next_arg()?;
+    
+    // This SET command will be intercepted by the filter if it's registered
+    ctx.call("SET", &[&key, &value])?;
+    
+    Ok(RedisValue::SimpleStringStatic("OK"))
+}
+
+fn filter_inspect(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
+    // Register a temporary filter that inspects and modifies arguments
+    let filter = ctx.register_command_filter(
+        |fctx: &CommandFilterContext| {
+            let argc = fctx.args_count();
+            
+            // Example: Intercept GET commands and log the client ID
+            if argc > 0 {
+                if let Some(cmd) = fctx.arg_get(0) {
+                    if let Ok(cmd_str) = cmd.try_as_str() {
+                        if cmd_str.eq_ignore_ascii_case("get") {
+                            let client_id = fctx.get_client_id();
+                            // In a real implementation, you might log this
+                            // or store it for later use
+                            let _ = client_id;
+                        }
+                    }
+                }
+            }
+        },
+        0,
+    );
+    
+    // Execute a GET command which will be intercepted
+    if args.len() > 1 {
+        let _ = ctx.call("GET", &[&args[1]]);
+    }
+    
+    // Unregister the filter
+    ctx.unregister_command_filter(filter)?;
+    
+    Ok(RedisValue::SimpleStringStatic("OK"))
+}
+
+fn filter_modify(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
+    // Example showing argument modification
+    let filter = ctx.register_command_filter(
+        |fctx: &CommandFilterContext| {
+            let argc = fctx.args_count();
+            
+            // Example: Intercept SET commands and append a prefix to the key
+            if argc >= 2 {
+                if let Some(cmd) = fctx.arg_get(0) {
+                    if let Ok(cmd_str) = cmd.try_as_str() {
+                        if cmd_str.eq_ignore_ascii_case("set") {
+                            if let Some(key) = fctx.arg_get(1) {
+                                if let Ok(key_str) = key.try_as_str() {
+                                    // Create a new key with prefix
+                                    let new_key_str = format!("filtered:{}", key_str);
+                                    
+                                    // Note: We would need a way to create a RedisString
+                                    // without a Context here, which is a limitation
+                                    // of the current API design
+                                    let _ = new_key_str;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        0,
+    );
+    
+    // Execute a command
+    if args.len() > 2 {
+        let _ = ctx.call("SET", &[&args[1], &args[2]]);
+    }
+    
+    // Unregister the filter
+    ctx.unregister_command_filter(filter)?;
+    
+    Ok(RedisValue::SimpleStringStatic("OK"))
+}
+
+//////////////////////////////////////////////////////
+
+redis_module! {
+    name: "command_filter",
+    version: 1,
+    allocator: (redis_module::alloc::RedisAlloc, redis_module::alloc::RedisAlloc),
+    data_types: [],
+    commands: [
+        ["filter.register", filter_register, "", 0, 0, 0, ""],
+        ["filter.unregister", filter_unregister, "", 0, 0, 0, ""],
+        ["filter.test_args", filter_test_args, "", 0, 0, 0, ""],
+        ["filter.inspect", filter_inspect, "", 0, 0, 0, ""],
+        ["filter.modify", filter_modify, "", 0, 0, 0, ""],
+    ],
+}

--- a/examples/command_filter.rs
+++ b/examples/command_filter.rs
@@ -1,53 +1,57 @@
 use redis_module::{
-    redis_module, Context, NextArg, RedisError, RedisResult, RedisString, RedisValue,
+    raw, redis_module, Context, NextArg, RedisError, RedisResult, RedisString, RedisValue,
 };
 use redis_module::CommandFilterContext;
+use std::sync::atomic::{AtomicPtr, Ordering};
 
-static mut COMMAND_FILTER: Option<*mut redis_module::raw::RedisModuleCommandFilter> = None;
+static COMMAND_FILTER: AtomicPtr<raw::RedisModuleCommandFilter> = AtomicPtr::new(std::ptr::null_mut());
 
-fn command_filter_callback(fctx: &CommandFilterContext) {
+unsafe extern "C" fn command_filter_callback(fctx: *mut raw::RedisModuleCommandFilterCtx) {
+    let filter_ctx = CommandFilterContext::new(fctx);
+    command_filter_impl(&filter_ctx);
+}
+
+fn command_filter_impl(fctx: &CommandFilterContext) {
     // Get the number of arguments
     let argc = fctx.args_count();
     
     if argc > 0 {
         // Get the command name (first argument)
-        if let Some(cmd) = fctx.arg_get(0) {
-            if let Ok(cmd_str) = cmd.try_as_str() {
-                // Example: Log all SET commands
-                if cmd_str.eq_ignore_ascii_case("set") {
-                    // You can inspect or modify arguments here
-                    // For example, you could replace sensitive data
-                    
-                    // Note: In a real implementation, you would use the Context
-                    // to log, but we don't have access to it in the filter callback
-                }
+        if let Some(cmd_str) = fctx.arg_get_str(0) {
+            // Example: Log all SET commands
+            if cmd_str.eq_ignore_ascii_case("set") {
+                // You can inspect or modify arguments here
+                // For example, you could replace sensitive data
+                
+                // Note: In a real implementation, you would use the Context
+                // to log, but we don't have access to it in the filter callback
+                let _client_id = fctx.get_client_id();
             }
         }
     }
 }
 
 fn filter_register(ctx: &Context, _args: Vec<RedisString>) -> RedisResult {
-    unsafe {
-        if COMMAND_FILTER.is_some() {
-            return Err(RedisError::String("Filter already registered".to_string()));
-        }
-        
-        let filter = ctx.register_command_filter(command_filter_callback, 0);
-        COMMAND_FILTER = Some(filter);
+    let current = COMMAND_FILTER.load(Ordering::Acquire);
+    
+    if !current.is_null() {
+        return Err(RedisError::String("Filter already registered".to_string()));
     }
+    
+    let filter = unsafe { ctx.register_command_filter(command_filter_callback, 0) };
+    COMMAND_FILTER.store(filter, Ordering::Release);
     
     Ok(RedisValue::SimpleStringStatic("OK"))
 }
 
 fn filter_unregister(ctx: &Context, _args: Vec<RedisString>) -> RedisResult {
-    unsafe {
-        if let Some(filter) = COMMAND_FILTER {
-            ctx.unregister_command_filter(filter)?;
-            COMMAND_FILTER = None;
-            Ok(RedisValue::SimpleStringStatic("OK"))
-        } else {
-            Err(RedisError::String("No filter registered".to_string()))
-        }
+    let filter = COMMAND_FILTER.swap(std::ptr::null_mut(), Ordering::AcqRel);
+    
+    if !filter.is_null() {
+        ctx.unregister_command_filter(filter)?;
+        Ok(RedisValue::SimpleStringStatic("OK"))
+    } else {
+        Err(RedisError::String("No filter registered".to_string()))
     }
 }
 
@@ -58,81 +62,6 @@ fn filter_test_args(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     
     // This SET command will be intercepted by the filter if it's registered
     ctx.call("SET", &[&key, &value])?;
-    
-    Ok(RedisValue::SimpleStringStatic("OK"))
-}
-
-fn filter_inspect(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
-    // Register a temporary filter that inspects and modifies arguments
-    let filter = ctx.register_command_filter(
-        |fctx: &CommandFilterContext| {
-            let argc = fctx.args_count();
-            
-            // Example: Intercept GET commands and log the client ID
-            if argc > 0 {
-                if let Some(cmd) = fctx.arg_get(0) {
-                    if let Ok(cmd_str) = cmd.try_as_str() {
-                        if cmd_str.eq_ignore_ascii_case("get") {
-                            let client_id = fctx.get_client_id();
-                            // In a real implementation, you might log this
-                            // or store it for later use
-                            let _ = client_id;
-                        }
-                    }
-                }
-            }
-        },
-        0,
-    );
-    
-    // Execute a GET command which will be intercepted
-    if args.len() > 1 {
-        let _ = ctx.call("GET", &[&args[1]]);
-    }
-    
-    // Unregister the filter
-    ctx.unregister_command_filter(filter)?;
-    
-    Ok(RedisValue::SimpleStringStatic("OK"))
-}
-
-fn filter_modify(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
-    // Example showing argument modification
-    let filter = ctx.register_command_filter(
-        |fctx: &CommandFilterContext| {
-            let argc = fctx.args_count();
-            
-            // Example: Intercept SET commands and append a prefix to the key
-            if argc >= 2 {
-                if let Some(cmd) = fctx.arg_get(0) {
-                    if let Ok(cmd_str) = cmd.try_as_str() {
-                        if cmd_str.eq_ignore_ascii_case("set") {
-                            if let Some(key) = fctx.arg_get(1) {
-                                if let Ok(key_str) = key.try_as_str() {
-                                    // Create a new key with prefix
-                                    let new_key_str = format!("filtered:{}", key_str);
-                                    
-                                    // Note: We would need a way to create a RedisString
-                                    // without a Context here, which is a limitation
-                                    // of the current API design
-                                    let _ = new_key_str;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        0,
-    );
-    
-    // Execute a command
-    if args.len() > 2 {
-        let _ = ctx.call("SET", &[&args[1], &args[2]]);
-    }
-    
-    // Unregister the filter
-    ctx.unregister_command_filter(filter)?;
     
     Ok(RedisValue::SimpleStringStatic("OK"))
 }
@@ -148,7 +77,5 @@ redis_module! {
         ["filter.register", filter_register, "", 0, 0, 0, ""],
         ["filter.unregister", filter_unregister, "", 0, 0, 0, ""],
         ["filter.test_args", filter_test_args, "", 0, 0, 0, ""],
-        ["filter.inspect", filter_inspect, "", 0, 0, 0, ""],
-        ["filter.modify", filter_modify, "", 0, 0, 0, ""],
     ],
 }

--- a/examples/command_filter.rs
+++ b/examples/command_filter.rs
@@ -1,30 +1,37 @@
 use redis_module::{
     raw, redis_module, Context, NextArg, RedisError, RedisResult, RedisString, RedisValue,
+    CommandFilter, CommandFilterContext,
 };
-use redis_module::CommandFilterContext;
 use std::sync::atomic::{AtomicPtr, Ordering};
 
-static COMMAND_FILTER: AtomicPtr<raw::RedisModuleCommandFilter> = AtomicPtr::new(std::ptr::null_mut());
+static COMMAND_FILTER: AtomicPtr<raw::RedisModuleCommandFilter> = 
+    AtomicPtr::new(std::ptr::null_mut());
 
-unsafe extern "C" fn command_filter_callback(fctx: *mut raw::RedisModuleCommandFilterCtx) {
+extern "C" fn command_filter_callback(fctx: *mut raw::RedisModuleCommandFilterCtx) {
     let filter_ctx = CommandFilterContext::new(fctx);
     command_filter_impl(&filter_ctx);
 }
 
 fn command_filter_impl(fctx: &CommandFilterContext) {
-    // Get the number of arguments
-    let argc = fctx.args_count();
-    
-    if argc > 0 {
-        // Get the command name (first argument)
-        if let Some(cmd_str) = fctx.arg_get_str(0) {
-            // Example: Log all SET commands
-            if cmd_str.eq_ignore_ascii_case("set") {
-                // You can inspect or modify arguments here
-                // For example, you could replace sensitive data
-                
-                // Note: In a real implementation, you would use the Context
-                // to log, but we don't have access to it in the filter callback
+    // Get the command name
+    if let Ok(cmd_str) = fctx.cmd_get_try_as_str() {
+        // Example: Log all SET commands
+        if cmd_str.eq_ignore_ascii_case("set") {
+            // You can inspect or modify arguments here
+            // For example, you could replace sensitive data
+            
+            // Get all arguments (excluding command)
+            let args = fctx.get_all_args_wo_cmd();
+            let _num_args = args.len();
+            
+            // Note: In a real implementation, you would use the Context
+            // to log, but we don't have access to it in the filter callback
+            
+            #[cfg(any(
+                feature = "min-redis-compatibility-version-7-4",
+                feature = "min-redis-compatibility-version-7-2"
+            ))]
+            {
                 let _client_id = fctx.get_client_id();
             }
         }
@@ -38,17 +45,18 @@ fn filter_register(ctx: &Context, _args: Vec<RedisString>) -> RedisResult {
         return Err(RedisError::String("Filter already registered".to_string()));
     }
     
-    let filter = unsafe { ctx.register_command_filter(command_filter_callback, 0) };
-    COMMAND_FILTER.store(filter, Ordering::Release);
+    let filter = ctx.register_command_filter(command_filter_callback, 0);
+    COMMAND_FILTER.store(filter.as_ptr(), Ordering::Release);
     
     Ok(RedisValue::SimpleStringStatic("OK"))
 }
 
 fn filter_unregister(ctx: &Context, _args: Vec<RedisString>) -> RedisResult {
-    let filter = COMMAND_FILTER.swap(std::ptr::null_mut(), Ordering::AcqRel);
+    let filter_ptr = COMMAND_FILTER.swap(std::ptr::null_mut(), Ordering::AcqRel);
     
-    if !filter.is_null() {
-        ctx.unregister_command_filter(filter)?;
+    if !filter_ptr.is_null() {
+        let filter = CommandFilter::new(filter_ptr);
+        ctx.unregister_command_filter(&filter);
         Ok(RedisValue::SimpleStringStatic("OK"))
     } else {
         Err(RedisError::String("No filter registered".to_string()))
@@ -66,6 +74,39 @@ fn filter_test_args(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     Ok(RedisValue::SimpleStringStatic("OK"))
 }
 
+fn filter_modify_example(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
+    // This example demonstrates how to modify command arguments in a filter
+    // In this case, we'll register a temporary filter that adds a prefix to SET keys
+    
+    extern "C" fn modify_filter(fctx: *mut raw::RedisModuleCommandFilterCtx) {
+        let filter_ctx = CommandFilterContext::new(fctx);
+        
+        // Check if this is a SET command
+        if let Ok(cmd) = filter_ctx.cmd_get_try_as_str() {
+            if cmd.eq_ignore_ascii_case("set") && filter_ctx.args_count() >= 2 {
+                // Get the current key
+                if let Ok(key) = filter_ctx.arg_get_try_as_str(1) {
+                    // Replace it with a prefixed version
+                    let new_key = format!("filtered:{}", key);
+                    filter_ctx.arg_replace(1, &new_key);
+                }
+            }
+        }
+    }
+    
+    let filter = ctx.register_command_filter(modify_filter, 0);
+    
+    // Execute a SET command which will be modified by the filter
+    if args.len() > 2 {
+        let _ = ctx.call("SET", &[&args[1], &args[2]]);
+    }
+    
+    // Unregister the filter
+    ctx.unregister_command_filter(&filter);
+    
+    Ok(RedisValue::SimpleStringStatic("OK"))
+}
+
 //////////////////////////////////////////////////////
 
 redis_module! {
@@ -77,5 +118,6 @@ redis_module! {
         ["filter.register", filter_register, "", 0, 0, 0, ""],
         ["filter.unregister", filter_unregister, "", 0, 0, 0, ""],
         ["filter.test_args", filter_test_args, "", 0, 0, 0, ""],
+        ["filter.modify_example", filter_modify_example, "", 0, 0, 0, ""],
     ],
 }

--- a/src/context/command_filter.rs
+++ b/src/context/command_filter.rs
@@ -28,7 +28,7 @@ impl CommandFilter {
     }
 
     /// Get the raw pointer to the filter.
-    /// 
+    ///
     /// This is useful when you need to store the filter handle and later
     /// recreate the CommandFilter wrapper.
     pub fn as_ptr(&self) -> *mut raw::RedisModuleCommandFilter {

--- a/src/context/command_filter.rs
+++ b/src/context/command_filter.rs
@@ -1,0 +1,236 @@
+use std::collections::HashMap;
+use std::os::raw::c_int;
+use std::sync::{Mutex, OnceLock};
+
+use crate::raw;
+use crate::{Context, RedisError, RedisString};
+
+/// A wrapper around the Redis Module Command Filter Context.
+///
+/// This context is passed to command filter callbacks and provides methods
+/// to inspect and modify command arguments.
+pub struct CommandFilterContext {
+    fctx: *mut raw::RedisModuleCommandFilterCtx,
+}
+
+impl CommandFilterContext {
+    /// Create a new CommandFilterContext from a raw pointer.
+    ///
+    /// # Safety
+    /// The caller must ensure that the pointer is valid.
+    pub(crate) unsafe fn new(fctx: *mut raw::RedisModuleCommandFilterCtx) -> Self {
+        CommandFilterContext { fctx }
+    }
+
+    /// Get the number of arguments in the filtered command.
+    ///
+    /// Wrapper for `RedisModule_CommandFilterArgsCount`.
+    pub fn args_count(&self) -> c_int {
+        unsafe { raw::RedisModule_CommandFilterArgsCount.unwrap()(self.fctx) }
+    }
+
+    /// Get the argument at the specified position.
+    ///
+    /// Wrapper for `RedisModule_CommandFilterArgGet`.
+    ///
+    /// # Arguments
+    /// * `pos` - The position of the argument (0-based)
+    ///
+    /// # Returns
+    /// The argument as a RedisString, or None if the position is out of bounds.
+    pub fn arg_get(&self, pos: c_int) -> Option<RedisString> {
+        unsafe {
+            let ptr = raw::RedisModule_CommandFilterArgGet.unwrap()(self.fctx, pos);
+            if ptr.is_null() {
+                None
+            } else {
+                // Note: The returned string should not be retained by the module.
+                // We create a RedisString wrapper but pass null for the context
+                // since we don't have access to it here.
+                Some(RedisString::from_redis_module_string(
+                    std::ptr::null_mut(),
+                    ptr,
+                ))
+            }
+        }
+    }
+
+    /// Insert an argument at the specified position.
+    ///
+    /// Wrapper for `RedisModule_CommandFilterArgInsert`.
+    ///
+    /// # Arguments
+    /// * `pos` - The position where the argument should be inserted (0-based)
+    /// * `arg` - The argument to insert
+    ///
+    /// # Returns
+    /// Ok(()) on success, or an error if the operation failed.
+    pub fn arg_insert(&self, pos: c_int, arg: &RedisString) -> Result<(), RedisError> {
+        let status: raw::Status = unsafe {
+            raw::RedisModule_CommandFilterArgInsert.unwrap()(self.fctx, pos, arg.inner)
+        }
+        .into();
+
+        if status == raw::Status::Ok {
+            Ok(())
+        } else {
+            Err(RedisError::Str("Failed to insert argument"))
+        }
+    }
+
+    /// Replace the argument at the specified position.
+    ///
+    /// Wrapper for `RedisModule_CommandFilterArgReplace`.
+    ///
+    /// # Arguments
+    /// * `pos` - The position of the argument to replace (0-based)
+    /// * `arg` - The new argument value
+    ///
+    /// # Returns
+    /// Ok(()) on success, or an error if the operation failed.
+    pub fn arg_replace(&self, pos: c_int, arg: &RedisString) -> Result<(), RedisError> {
+        let status: raw::Status = unsafe {
+            raw::RedisModule_CommandFilterArgReplace.unwrap()(self.fctx, pos, arg.inner)
+        }
+        .into();
+
+        if status == raw::Status::Ok {
+            Ok(())
+        } else {
+            Err(RedisError::Str("Failed to replace argument"))
+        }
+    }
+
+    /// Delete the argument at the specified position.
+    ///
+    /// Wrapper for `RedisModule_CommandFilterArgDelete`.
+    ///
+    /// # Arguments
+    /// * `pos` - The position of the argument to delete (0-based)
+    ///
+    /// # Returns
+    /// Ok(()) on success, or an error if the operation failed.
+    pub fn arg_delete(&self, pos: c_int) -> Result<(), RedisError> {
+        let status: raw::Status =
+            unsafe { raw::RedisModule_CommandFilterArgDelete.unwrap()(self.fctx, pos) }.into();
+
+        if status == raw::Status::Ok {
+            Ok(())
+        } else {
+            Err(RedisError::Str("Failed to delete argument"))
+        }
+    }
+
+    /// Get the client ID of the client that issued the filtered command.
+    ///
+    /// Wrapper for `RedisModule_CommandFilterGetClientId`.
+    ///
+    /// # Returns
+    /// The client ID as an unsigned 64-bit integer.
+    pub fn get_client_id(&self) -> u64 {
+        unsafe { raw::RedisModule_CommandFilterGetClientId.unwrap()(self.fctx) }
+    }
+}
+
+/// Type alias for command filter callbacks.
+pub type CommandFilterCallback = fn(&CommandFilterContext);
+
+// Global registry to store filter callbacks
+// The key is the filter pointer, the value is the callback function
+static FILTER_REGISTRY: OnceLock<Mutex<HashMap<usize, CommandFilterCallback>>> = OnceLock::new();
+
+fn get_filter_registry() -> &'static Mutex<HashMap<usize, CommandFilterCallback>> {
+    FILTER_REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+impl Context {
+    /// Register a command filter callback.
+    ///
+    /// Wrapper for `RedisModule_RegisterCommandFilter`.
+    ///
+    /// The callback will be invoked for each command executed. Note that the
+    /// callback must be a function pointer (not a closure) due to limitations
+    /// in the Redis Module API.
+    ///
+    /// # Arguments
+    /// * `callback` - The callback function to be invoked for each command
+    /// * `flags` - Flags for the command filter (currently unused, pass 0)
+    ///
+    /// # Returns
+    /// A pointer to the registered command filter, which can be used to unregister it later.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use redis_module::{Context, RedisResult};
+    /// # use redis_module::context::command_filter::CommandFilterContext;
+    /// fn my_filter(fctx: &CommandFilterContext) {
+    ///     // Filter logic here
+    /// }
+    ///
+    /// fn my_command(ctx: &Context, _args: Vec<redis_module::RedisString>) -> RedisResult {
+    ///     let filter = ctx.register_command_filter(my_filter, 0);
+    ///     // ...later...
+    ///     ctx.unregister_command_filter(filter)?;
+    ///     Ok(().into())
+    /// }
+    /// ```
+    pub fn register_command_filter(
+        &self,
+        callback: CommandFilterCallback,
+        flags: c_int,
+    ) -> *mut raw::RedisModuleCommandFilter {
+        let filter_ptr = unsafe {
+            raw::RedisModule_RegisterCommandFilter.unwrap()(
+                self.ctx,
+                Some(raw_filter_callback),
+                flags,
+            )
+        };
+
+        // Store the callback in the registry
+        let mut registry = get_filter_registry().lock().unwrap();
+        registry.insert(filter_ptr as usize, callback);
+
+        filter_ptr
+    }
+
+    /// Unregister a previously registered command filter.
+    ///
+    /// Wrapper for `RedisModule_UnregisterCommandFilter`.
+    ///
+    /// # Arguments
+    /// * `filter` - The filter pointer returned by `register_command_filter`
+    ///
+    /// # Returns
+    /// Ok(()) on success, or an error if the operation failed.
+    pub fn unregister_command_filter(
+        &self,
+        filter: *mut raw::RedisModuleCommandFilter,
+    ) -> Result<(), RedisError> {
+        let status: raw::Status =
+            unsafe { raw::RedisModule_UnregisterCommandFilter.unwrap()(self.ctx, filter) }.into();
+
+        if status == raw::Status::Ok {
+            // Remove the callback from the registry
+            let mut registry = get_filter_registry().lock().unwrap();
+            registry.remove(&(filter as usize));
+            Ok(())
+        } else {
+            Err(RedisError::Str(
+                "Failed to unregister command filter, filter may not exist",
+            ))
+        }
+    }
+}
+
+extern "C" fn raw_filter_callback(fctx: *mut raw::RedisModuleCommandFilterCtx) {
+    let ctx = unsafe { CommandFilterContext::new(fctx) };
+
+    // Call all registered callbacks
+    // Note: Since the C API doesn't give us a way to identify which filter this is,
+    // we call all registered callbacks. This is a limitation of the current approach.
+    let registry = get_filter_registry().lock().unwrap();
+    for callback in registry.values() {
+        callback(&ctx);
+    }
+}

--- a/src/context/command_filter.rs
+++ b/src/context/command_filter.rs
@@ -1,14 +1,47 @@
 use std::os::raw::c_int;
+use std::str::Utf8Error;
 
 use crate::raw;
-use crate::{Context, RedisError, RedisString};
+use crate::{Context, RedisString};
+
+/// A wrapper around the Redis Module Command Filter pointer.
+///
+/// This provides a type-safe way to work with command filter handles.
+#[derive(Debug, Clone, Copy)]
+pub struct CommandFilter {
+    pub(crate) inner: *mut raw::RedisModuleCommandFilter,
+}
+
+// Required for thread-safe storage of command filters
+unsafe impl Send for CommandFilter {}
+unsafe impl Sync for CommandFilter {}
+
+impl CommandFilter {
+    /// Create a new CommandFilter from a raw pointer.
+    pub fn new(inner: *mut raw::RedisModuleCommandFilter) -> Self {
+        CommandFilter { inner }
+    }
+
+    /// Check if the filter pointer is null.
+    pub fn is_null(&self) -> bool {
+        self.inner.is_null()
+    }
+
+    /// Get the raw pointer to the filter.
+    /// 
+    /// This is useful when you need to store the filter handle and later
+    /// recreate the CommandFilter wrapper.
+    pub fn as_ptr(&self) -> *mut raw::RedisModuleCommandFilter {
+        self.inner
+    }
+}
 
 /// A wrapper around the Redis Module Command Filter Context.
 ///
 /// This context is passed to command filter callbacks and provides methods
 /// to inspect and modify command arguments.
 pub struct CommandFilterContext {
-    fctx: *mut raw::RedisModuleCommandFilterCtx,
+    inner: *mut raw::RedisModuleCommandFilterCtx,
 }
 
 impl CommandFilterContext {
@@ -17,18 +50,18 @@ impl CommandFilterContext {
     /// # Safety
     /// The caller must ensure that the pointer is valid and only used within
     /// the lifetime of the command filter callback.
-    pub unsafe fn new(fctx: *mut raw::RedisModuleCommandFilterCtx) -> Self {
-        CommandFilterContext { fctx }
+    pub fn new(inner: *mut raw::RedisModuleCommandFilterCtx) -> Self {
+        CommandFilterContext { inner }
     }
 
     /// Get the number of arguments in the filtered command.
     ///
     /// Wrapper for `RedisModule_CommandFilterArgsCount`.
     pub fn args_count(&self) -> c_int {
-        unsafe { raw::RedisModule_CommandFilterArgsCount.unwrap()(self.fctx) }
+        unsafe { raw::RedisModule_CommandFilterArgsCount.unwrap()(self.inner) }
     }
 
-    /// Get the argument at the specified position as a string slice.
+    /// Get the argument at the specified position as a raw pointer.
     ///
     /// Wrapper for `RedisModule_CommandFilterArgGet`.
     ///
@@ -36,44 +69,52 @@ impl CommandFilterContext {
     /// * `pos` - The position of the argument (0-based)
     ///
     /// # Returns
-    /// The argument as a string slice, or None if the position is out of bounds
-    /// or the argument is not valid UTF-8.
-    ///
-    /// # Note
-    /// The returned string slice is only valid for the duration of the filter callback.
-    /// Do not store it beyond the callback's lifetime.
-    pub fn arg_get_str(&self, pos: c_int) -> Option<&str> {
-        unsafe {
-            let ptr = raw::RedisModule_CommandFilterArgGet.unwrap()(self.fctx, pos);
-            if ptr.is_null() {
-                None
-            } else {
-                RedisString::from_ptr(ptr).ok()
-            }
-        }
+    /// A pointer to the RedisModuleString, or null if the position is out of bounds.
+    pub fn arg_get(&self, pos: c_int) -> *mut raw::RedisModuleString {
+        unsafe { raw::RedisModule_CommandFilterArgGet.unwrap()(self.inner, pos) }
     }
 
-    /// Insert an argument at the specified position.
+    /// Get the argument at the specified position as a string slice.
     ///
-    /// Wrapper for `RedisModule_CommandFilterArgInsert`.
+    /// Wrapper for `RedisModule_CommandFilterArgGet` with automatic conversion to `&str`.
     ///
     /// # Arguments
-    /// * `pos` - The position where the argument should be inserted (0-based)
-    /// * `arg` - The argument to insert
+    /// * `pos` - The position of the argument (0-based)
     ///
     /// # Returns
-    /// Ok(()) on success, or an error if the operation failed.
-    pub fn arg_insert(&self, pos: c_int, arg: &RedisString) -> Result<(), RedisError> {
-        let status: raw::Status = unsafe {
-            raw::RedisModule_CommandFilterArgInsert.unwrap()(self.fctx, pos, arg.inner)
-        }
-        .into();
+    /// The argument as a string slice, or an error if the position is out of bounds
+    /// or the argument is not valid UTF-8.
+    pub fn arg_get_try_as_str(&self, pos: c_int) -> Result<&str, Utf8Error> {
+        let arg = self.arg_get(pos);
+        RedisString::from_ptr(arg)
+    }
 
-        if status == raw::Status::Ok {
-            Ok(())
-        } else {
-            Err(RedisError::Str("Failed to insert argument"))
+    /// Get the command name (the 0th argument) as a string slice.
+    ///
+    /// This is a convenience wrapper that always fetches argument 0, which is
+    /// the command name.
+    ///
+    /// # Returns
+    /// The command name as a string slice, or an error if not valid UTF-8.
+    pub fn cmd_get_try_as_str(&self) -> Result<&str, Utf8Error> {
+        self.arg_get_try_as_str(0)
+    }
+
+    /// Get all arguments except the command name.
+    ///
+    /// This is a convenience method that returns a vector of all arguments
+    /// starting from position 1 (skipping the command name at position 0).
+    ///
+    /// # Returns
+    /// A vector of string slices containing all arguments. Invalid UTF-8 arguments are skipped.
+    pub fn get_all_args_wo_cmd(&self) -> Vec<&str> {
+        let mut output = Vec::new();
+        for pos in 1..self.args_count() {
+            if let Ok(arg) = self.arg_get_try_as_str(pos) {
+                output.push(arg);
+            }
         }
+        output
     }
 
     /// Replace the argument at the specified position.
@@ -82,21 +123,28 @@ impl CommandFilterContext {
     ///
     /// # Arguments
     /// * `pos` - The position of the argument to replace (0-based)
-    /// * `arg` - The new argument value
-    ///
-    /// # Returns
-    /// Ok(()) on success, or an error if the operation failed.
-    pub fn arg_replace(&self, pos: c_int, arg: &RedisString) -> Result<(), RedisError> {
-        let status: raw::Status = unsafe {
-            raw::RedisModule_CommandFilterArgReplace.unwrap()(self.fctx, pos, arg.inner)
-        }
-        .into();
+    /// * `arg` - The new argument value as a string slice
+    pub fn arg_replace(&self, pos: c_int, arg: &str) {
+        unsafe {
+            let new_arg = RedisString::create(None, arg);
+            raw::string_retain_string(std::ptr::null_mut(), new_arg.inner);
+            raw::RedisModule_CommandFilterArgReplace.unwrap()(self.inner, pos, new_arg.inner)
+        };
+    }
 
-        if status == raw::Status::Ok {
-            Ok(())
-        } else {
-            Err(RedisError::Str("Failed to replace argument"))
-        }
+    /// Insert an argument at the specified position.
+    ///
+    /// Wrapper for `RedisModule_CommandFilterArgInsert`.
+    ///
+    /// # Arguments
+    /// * `pos` - The position where the argument should be inserted (0-based)
+    /// * `arg` - The argument to insert as a string slice
+    pub fn arg_insert(&self, pos: c_int, arg: &str) {
+        unsafe {
+            let new_arg = RedisString::create(None, arg);
+            raw::string_retain_string(std::ptr::null_mut(), new_arg.inner);
+            raw::RedisModule_CommandFilterArgInsert.unwrap()(self.inner, pos, new_arg.inner)
+        };
     }
 
     /// Delete the argument at the specified position.
@@ -105,18 +153,8 @@ impl CommandFilterContext {
     ///
     /// # Arguments
     /// * `pos` - The position of the argument to delete (0-based)
-    ///
-    /// # Returns
-    /// Ok(()) on success, or an error if the operation failed.
-    pub fn arg_delete(&self, pos: c_int) -> Result<(), RedisError> {
-        let status: raw::Status =
-            unsafe { raw::RedisModule_CommandFilterArgDelete.unwrap()(self.fctx, pos) }.into();
-
-        if status == raw::Status::Ok {
-            Ok(())
-        } else {
-            Err(RedisError::Str("Failed to delete argument"))
-        }
+    pub fn arg_delete(&self, pos: c_int) {
+        unsafe { raw::RedisModule_CommandFilterArgDelete.unwrap()(self.inner, pos) };
     }
 
     /// Get the client ID of the client that issued the filtered command.
@@ -125,58 +163,61 @@ impl CommandFilterContext {
     ///
     /// # Returns
     /// The client ID as an unsigned 64-bit integer.
+    ///
+    /// # Note
+    /// This API is not supported in Redis 7.0. It requires Redis 7.2 or later.
+    #[cfg(any(
+        feature = "min-redis-compatibility-version-7-4",
+        feature = "min-redis-compatibility-version-7-2"
+    ))]
     pub fn get_client_id(&self) -> u64 {
-        unsafe { raw::RedisModule_CommandFilterGetClientId.unwrap()(self.fctx) }
+        unsafe { raw::RedisModule_CommandFilterGetClientId.unwrap()(self.inner) }
     }
 }
-
-/// Type alias for command filter callbacks.
-///
-/// Note: Due to limitations in the Redis Module C API, command filters cannot receive
-/// user data. Therefore, the callback must be a static function pointer, not a closure
-/// that captures variables.
-pub type CommandFilterCallback = unsafe extern "C" fn(*mut raw::RedisModuleCommandFilterCtx);
 
 impl Context {
     /// Register a command filter callback.
     ///
     /// Wrapper for `RedisModule_RegisterCommandFilter`.
     ///
-    /// The callback will be invoked for each command executed. Due to limitations
-    /// in the Redis Module C API, the callback must be an `extern "C"` function that
-    /// matches the signature expected by Redis.
-    ///
-    /// Typically, you would create a wrapper function that calls your Rust implementation:
-    ///
-    /// ```no_run
-    /// # use redis_module::raw;
-    /// # use redis_module::CommandFilterContext;
-    /// unsafe extern "C" fn my_filter_wrapper(fctx: *mut raw::RedisModuleCommandFilterCtx) {
-    ///     let filter_ctx = CommandFilterContext::new(fctx);
-    ///     my_filter_impl(&filter_ctx);
-    /// }
-    ///
-    /// fn my_filter_impl(fctx: &CommandFilterContext) {
-    ///     // Your filter logic here
-    /// }
-    /// ```
+    /// The callback will be invoked for each command executed. The callback
+    /// should be an `extern "C"` function that accepts a command filter context.
     ///
     /// # Arguments
     /// * `callback` - The callback function to be invoked for each command
     /// * `flags` - Flags for the command filter (currently unused, pass 0)
     ///
     /// # Returns
-    /// A pointer to the registered command filter, which can be used to unregister it later.
+    /// A CommandFilter handle that can be used to unregister the filter later.
     ///
-    /// # Safety
-    /// The caller must ensure that the callback function is valid and properly handles
-    /// the raw pointer it receives.
-    pub unsafe fn register_command_filter(
+    /// # Example
+    /// ```no_run
+    /// # use redis_module::{Context, RedisResult};
+    /// # use redis_module::CommandFilterContext;
+    /// extern "C" fn my_filter(fctx: *mut redis_module::raw::RedisModuleCommandFilterCtx) {
+    ///     let filter_ctx = CommandFilterContext::new(fctx);
+    ///     // Filter logic here
+    /// }
+    ///
+    /// fn init(ctx: &Context) -> RedisResult {
+    ///     let filter = ctx.register_command_filter(my_filter, 0);
+    ///     // Store filter for later unregistration if needed
+    ///     Ok(().into())
+    /// }
+    /// ```
+    pub fn register_command_filter(
         &self,
-        callback: CommandFilterCallback,
-        flags: c_int,
-    ) -> *mut raw::RedisModuleCommandFilter {
-        raw::RedisModule_RegisterCommandFilter.unwrap()(self.ctx, Some(callback), flags)
+        callback: extern "C" fn(*mut raw::RedisModuleCommandFilterCtx),
+        flags: u32,
+    ) -> CommandFilter {
+        let filter_ptr = unsafe {
+            raw::RedisModule_RegisterCommandFilter.unwrap()(
+                self.ctx,
+                Some(callback),
+                flags as c_int,
+            )
+        };
+        CommandFilter::new(filter_ptr)
     }
 
     /// Unregister a previously registered command filter.
@@ -184,23 +225,10 @@ impl Context {
     /// Wrapper for `RedisModule_UnregisterCommandFilter`.
     ///
     /// # Arguments
-    /// * `filter` - The filter pointer returned by `register_command_filter`
-    ///
-    /// # Returns
-    /// Ok(()) on success, or an error if the operation failed.
-    pub fn unregister_command_filter(
-        &self,
-        filter: *mut raw::RedisModuleCommandFilter,
-    ) -> Result<(), RedisError> {
-        let status: raw::Status =
-            unsafe { raw::RedisModule_UnregisterCommandFilter.unwrap()(self.ctx, filter) }.into();
-
-        if status == raw::Status::Ok {
-            Ok(())
-        } else {
-            Err(RedisError::Str(
-                "Failed to unregister command filter, filter may not exist",
-            ))
+    /// * `filter` - The filter handle returned by `register_command_filter`
+    pub fn unregister_command_filter(&self, filter: &CommandFilter) {
+        unsafe {
+            raw::RedisModule_UnregisterCommandFilter.unwrap()(self.ctx, filter.inner);
         }
     }
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -29,6 +29,7 @@ mod timer;
 
 pub mod blocked;
 pub mod call_reply;
+pub mod command_filter;
 pub mod commands;
 pub mod defrag;
 pub mod info;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ mod macros;
 mod utils;
 
 pub use crate::context::blocked::BlockedClient;
-pub use crate::context::command_filter::CommandFilterContext;
+pub use crate::context::command_filter::{CommandFilter, CommandFilterContext};
 pub use crate::context::thread_safe::{
     ContextGuard, DetachedFromClient, RedisGILGuard, RedisLockIndicator, ThreadSafeContext,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ mod macros;
 mod utils;
 
 pub use crate::context::blocked::BlockedClient;
+pub use crate::context::command_filter::CommandFilterContext;
 pub use crate::context::thread_safe::{
     ContextGuard, DetachedFromClient, RedisGILGuard, RedisLockIndicator, ThreadSafeContext,
 };


### PR DESCRIPTION
## Command Filter API Implementation - COMPLETE ✅

Implementation aligned with ValKey reference: https://github.com/valkey-io/valkeymodule-rs/blob/main/src/context/filter.rs

### Changes from ValKey alignment:
- [x] Added `CommandFilter` wrapper struct with `Send`/`Sync` for thread-safe usage
- [x] Changed `arg_insert`, `arg_replace`, `arg_delete` to accept `&str` instead of `&RedisString`
- [x] Added helper methods: `cmd_get_try_as_str()` and `get_all_args_wo_cmd()`
- [x] Made `register_command_filter` safe (not unsafe) and return `CommandFilter`
- [x] Made `unregister_command_filter` accept `&CommandFilter`
- [x] Added feature flag for `get_client_id` (requires Redis 7.2+)
- [x] Updated example with better ergonomics
- [x] Fixed cargo fmt formatting issues

### API Summary

**CommandFilter struct:**
- Type-safe wrapper around filter pointer
- Implements `Send` + `Sync` for thread-safe storage
- Methods: `new()`, `is_null()`, `as_ptr()`

**CommandFilterContext methods:**
- `args_count()` - Get number of arguments
- `arg_get(pos)` - Get raw RedisModuleString pointer
- `arg_get_try_as_str(pos)` - Get argument as `&str` (with UTF-8 validation)
- `cmd_get_try_as_str()` - Get command name (0th arg) as `&str`
- `get_all_args_wo_cmd()` - Get all arguments except command as `Vec<&str>`
- `arg_insert(pos, &str)` - Insert argument (accepts string slice)
- `arg_replace(pos, &str)` - Replace argument (accepts string slice)
- `arg_delete(pos)` - Delete argument
- `get_client_id()` - Get client ID (Redis 7.2+ only, feature-gated)

**Context methods:**
- `register_command_filter(callback, flags)` -> `CommandFilter`
- `unregister_command_filter(&CommandFilter)`

All 8 Command Filter C APIs from the issue are wrapped with idiomatic Rust interface.

<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

> 
> ----
> 
> *This section details on the original issue you should resolve*
> 
> <issue_title>Add support for Command Filter</issue_title>
> <issue_description>Add a Rust native support for for the Redis Module C APIs
> 
> ```C
> REDISMODULE_API RedisModuleCommandFilter * (*RedisModule_RegisterCommandFilter)(RedisModuleCtx *ctx, RedisModuleCommandFilterFunc cb, int flags) REDISMODULE_ATTR;
> REDISMODULE_API int (*RedisModule_UnregisterCommandFilter)(RedisModuleCtx *ctx, RedisModuleCommandFilter *filter) REDISMODULE_ATTR;
> REDISMODULE_API int (*RedisModule_CommandFilterArgsCount)(RedisModuleCommandFilterCtx *fctx) REDISMODULE_ATTR;
> REDISMODULE_API RedisModuleString * (*RedisModule_CommandFilterArgGet)(RedisModuleCommandFilterCtx *fctx, int pos) REDISMODULE_ATTR;
> REDISMODULE_API int (*RedisModule_CommandFilterArgInsert)(RedisModuleCommandFilterCtx *fctx, int pos, RedisModuleString *arg) REDISMODULE_ATTR;
> REDISMODULE_API int (*RedisModule_CommandFilterArgReplace)(RedisModuleCommandFilterCtx *fctx, int pos, RedisModuleString *arg) REDISMODULE_ATTR;
> REDISMODULE_API int (*RedisModule_CommandFilterArgDelete)(RedisModuleCommandFilterCtx *fctx, int pos) REDISMODULE_ATTR;
> REDISMODULE_API unsigned long long (*RedisModule_CommandFilterGetClientId)(RedisModuleCommandFilterCtx *fctx) REDISMODULE_ATTR;
> ```
> <br/>
> <hr/>
> 
> <details><summary>This repo is using Opire - what does it mean? 👇</summary><br/>💵 Everyone can add rewards for this issue commenting <code>/reward 100</code> (replace <code>100</code> with the amount).<br/>🕵️‍♂️ If someone starts working on this issue to earn the rewards, they can comment <code>/try</code> to let everyone know!<br/>🙌 And when they open the PR, they can comment <code>/claim FalkorDB/redismodule-rs#1</code> either in the PR description or in a PR's comment.<br/><br/>🪙 Also, everyone can tip any user commenting <code>/tip 20 @gkorland</code> (replace <code>20</code> with the amount, and <code>@gkorland</code> with the user to tip).<br/><br/>📖 If you want to learn more, check out our <a href="https://docs.opire.dev">documentation</a>.</details></issue_description>
> 
> ## Comments on the Issue (you are @copilot in this section)
> 
> <comments>
> </comments>
> 


</details>



<!-- START COPILOT CODING AGENT SUFFIX -->

- Fixes FalkorDB/redismodule-rs#1

<!-- START COPILOT CODING AGENT TIPS -->
---

✨ Let Copilot coding agent [set things up for you](https://github.com/FalkorDB/redismodule-rs/issues/new?title=✨+Set+up+Copilot+instructions&body=Configure%20instructions%20for%20this%20repository%20as%20documented%20in%20%5BBest%20practices%20for%20Copilot%20coding%20agent%20in%20your%20repository%5D%28https://gh.io/copilot-coding-agent-tips%29%2E%0A%0A%3COnboard%20this%20repo%3E&assignees=copilot) — coding agent works faster and does higher quality work when set up for your repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command filter API for Redis modules, enabling runtime registration and unregistration of filters.
  * Implemented argument inspection and modification capabilities to intercept and transform commands.
  * Included example demonstrating filter workflows: registration, argument testing, and dynamic argument modification.
  * Support for conditional client-id retrieval based on Redis version compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->