### PR TITLE
add new events

### DIFF
--- a/src/include/redismodule.h
+++ b/src/include/redismodule.h
@@ -232,6 +232,8 @@ This flag should not be used directly by the module.
 #define REDISMODULE_NOTIFY_LOADED (1<<12)     /* module only key space notification, indicate a key loaded from rdb */
 #define REDISMODULE_NOTIFY_MODULE (1<<13)     /* d, module key space notification */
 #define REDISMODULE_NOTIFY_NEW (1<<14)        /* n, new key notification */
+#define REDISMODULE_NOTIFY_OVERWRITTEN (1<<15)   /* o, key overwrite notification */
+#define REDISMODULE_NOTIFY_TYPE_CHANGED (1<<16) /* c, key type changed notification */
 /* RL Extension: */
 #define REDISMODULE_NOTIFY_TRIMMED (1<<30)     /* trimmed by reshard trimming */
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -141,6 +141,8 @@ bitflags! {
         const MODULE = REDISMODULE_NOTIFY_MODULE;
         const LOADED = REDISMODULE_NOTIFY_LOADED;
         const MISSED = REDISMODULE_NOTIFY_KEY_MISS;
+        const OVERWRITTEN = REDISMODULE_NOTIFY_OVERWRITTEN;
+        const TYPE_CHANGED = REDISMODULE_NOTIFY_TYPE_CHANGED;
         /// Does not include the [`Self::MISSED`] and [`Self::NEW`].
         ///
         /// Includes [`Self::GENERIC`], [`Self::STRING`], [`Self::LIST`],


### PR DESCRIPTION
 **PR Summary by Typo**
------------

#### Overview
This PR introduces two new event types, `OVERWRITTEN` and `TYPE_CHANGED`, for Redis modules. These events enable modules to receive notifications when a key's value is overwritten or when its underlying data type changes, enhancing observability.

#### Key Changes
- Defined new notification flags `REDISMODULE_NOTIFY_OVERWRITTEN` and `REDISMODULE_NOTIFY_TYPE_CHANGED` in `src/include/redismodule.h`.
- Added `OVERWRITTEN` and `TYPE_CHANGED` constants to the `bitflags!` macro in `src/raw.rs` for Rust module integration.
- Updated the `examples/events.rs` module to include new atomic counters, event handlers, and Redis commands to track and expose occurrences of these new events.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 25 (96.2%)      |
| Rework      | 1 (3.8%)      |
| Total Changes | 26         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new keyspace notification types for key overwrite and type change events, with corresponding module commands to track and access event counters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->